### PR TITLE
Fix "/rating" route and fix input animation in "Balance checker widget"

### DIFF
--- a/client/views/widgets/_small/queryBalance/balanceChecker1.html
+++ b/client/views/widgets/_small/queryBalance/balanceChecker1.html
@@ -7,7 +7,12 @@
             style="position: absolute; bottom: 9px; right: 9px"><i
                   class="material-icons tiny right">delete</i></a>
           {{/if}}
-            <input type="text" name="address" placeholder="input address">
+          <div class="row">
+            <div class="input-field col s12">
+              <input name="address" type="text">
+              <label>input address</label>
+            </div>
+          </div>
             <a href="#" class="btn query-balance">Query Balance</a>
             {{#if lastAddress}}
               <h6>{{lastAddress}} </h6>

--- a/lib/router.js
+++ b/lib/router.js
@@ -249,7 +249,8 @@ var sorters = {
 };
 
 CF.Rating = CF.Rating || {};
-CF.Rating.getKeyBySorter =  function getKeyBySorter(sorterobj){
+// if sorterobj is undefined (ie if no session value ) make it empty object
+CF.Rating.getKeyBySorter =  function getKeyBySorter( sorterobj = {} ){
   var ret = null;
   var key = _.keys(sorterobj).length && _.keys(sorterobj)[0];
   if (!key) return ret;


### PR DESCRIPTION
About route problem: 
In development mode "/rating" route would throw error. It was generated because function could not get session value. And session value is usually not defined for new users and for unathorized users.
This PR fixes it.